### PR TITLE
Bugfix for iframe autosize

### DIFF
--- a/epfl-emploi.php
+++ b/epfl-emploi.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: EPFL Emploi
  * Description: provides a shortcode to display job offers
- * Version: 1.8
+ * Version: 1.8.1
  * Author: Lucien Chaboudez
  * Contributors:
  * License: Copyright (c) 2019 Ecole Polytechnique Federale de Lausanne, Switzerland

--- a/js/script.js
+++ b/js/script.js
@@ -161,8 +161,8 @@ emploiFrame = jQuery( '<iframe src="' + src + '" name="' + document.location.hre
 * This will be used to resize iframe (if size has changed). */
 window.addEventListener('message', function(e)
 {
-    /* Extracting height from received message */
-    var h = Number( e.data.replace( /.*if_height=(\d+)(?:&|$)/, '$1' ) );
+    /* Extracting height from received message, as decimal value */
+    var h = Number( e.data.replace( /.*if_height=(\d+)(\.\d+)?(?:&|$)/, '$1' ) );
 
     if (!isNaN( h ) && h > 0 && h !== if_height)
     {


### PR DESCRIPTION
Petit problème dans l'expression régulière censée récupérer la hauteur de l'iframe via des messages envoyés par Umantis. A priori, cette regex a dû fonctionner par le passé (ou alors les tests ont été mal faits) et/ou depuis que la taille de l'iframe est en valeur décimale, ça a pété. Par contre, sur WordPress 5.2, ça s'affiche toujours correctement... par chance probablement.
Adaptation donc de la regex pour pouvoir prendre en compte les valeurs décimales.